### PR TITLE
Import relative locs; python3 compat

### DIFF
--- a/aggregation/aggregate.py
+++ b/aggregation/aggregate.py
@@ -25,8 +25,8 @@ from matplotlib import pyplot, colors
 import numpy as np
 from numpy import random
 from scipy import linalg, stats
-import generator
-from index import Index2D
+from . import generator
+from .index import Index2D
 
 
 if sys.version_info[0] >= 3:

--- a/aggregation/aspectratio.py
+++ b/aggregation/aspectratio.py
@@ -18,9 +18,12 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-import cPickle as pickle
+try:
+  import cPickle as pickle
+except:
+  import pickle
 import numpy as np
-import crystal, aggregate, generator, rotator
+from . import crystal, aggregate, generator, rotator
 
 def aspect_ratio():
     D_arr = np.exp(np.linspace(np.log(100e-6), np.log(3000e-6), 100))

--- a/aggregation/crystal.py
+++ b/aggregation/crystal.py
@@ -21,7 +21,7 @@ SOFTWARE.
 import numpy as np
 from numpy import array, sign
 from scipy.optimize import brentq
-import dendrite
+from . import dendrite
 
 
 class Crystal(object):

--- a/aggregation/demos.py
+++ b/aggregation/demos.py
@@ -20,8 +20,11 @@ SOFTWARE.
 
 import numpy
 from numpy import random, array
-import aggregate, generator, rotator, crystal
-import cPickle as pickle
+from . import aggregate, generator, rotator, crystal
+try:
+  import cPickle as pickle
+except:
+  import pickle
 
 def monodisp_demo(N=5):
    #cry = crystal.Plate(0.3e-3)

--- a/aggregation/deposition.py
+++ b/aggregation/deposition.py
@@ -19,8 +19,8 @@ SOFTWARE.
 """
 
 import numpy as np
-import mcs
-from index import Index3D
+from . import mcs
+from .index import Index3D
 
 DEPOSITION_IDENT = -2
 

--- a/aggregation/fallvelocity.py
+++ b/aggregation/fallvelocity.py
@@ -19,7 +19,7 @@ SOFTWARE.
 """
 
 import numpy as np
-import mcs
+from . import mcs
 
 
 g = 9.81 # gravitational acceleration [m/s^2]

--- a/aggregation/generator.py
+++ b/aggregation/generator.py
@@ -19,8 +19,8 @@ SOFTWARE.
 """
 
 import numpy as np
-import crystal
-import rotator
+from . import crystal
+from . import rotator
 
 
 class Generator(object):

--- a/aggregation/index.py
+++ b/aggregation/index.py
@@ -18,7 +18,11 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from itertools import izip, chain, product
+from itertools import chain, product
+try:
+  from itertools import izip as zip
+except:
+  pass
 import numpy as np
 
 
@@ -51,7 +55,7 @@ class Index2D(object):
             objects = coordinates
         X = np.array(coordinates)/self._elem_size
         X_i = X.astype(np.int32)
-        for ((x,y),(x_i,y_i),obj) in izip(X,X_i,objects):
+        for ((x,y),(x_i,y_i),obj) in zip(X,X_i,objects):
             try:
                 self._grid[(x_i,y_i)].append(((x,y),obj))
             except KeyError:
@@ -129,7 +133,7 @@ class Index3D(object):
 
         X = np.array(coordinates)/self._elem_size
         X_i = X.astype(np.int32)
-        for ((x,y,z),(x_i,y_i,z_i)) in izip(X,X_i):
+        for ((x,y,z),(x_i,y_i,z_i)) in zip(X,X_i):
             try:
                 self._grid[(x_i,y_i,z_i)].append((x,y,z))
             except KeyError:
@@ -146,7 +150,7 @@ class Index3D(object):
 
         X = np.array(coordinates)/self._elem_size
         X_i = X.astype(np.int32)
-        for ((x,y,z),(x_i,y_i,z_i)) in izip(X,X_i):
+        for ((x,y,z),(x_i,y_i,z_i)) in zip(X,X_i):
             try:
                 ind = self._grid[(x_i,y_i,z_i)].index((x,y,z))
             except ValueError:

--- a/aggregation/mcs.py
+++ b/aggregation/mcs.py
@@ -18,7 +18,10 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from itertools import izip as zip
+try:
+  from itertools import izip as zip
+except:
+  pass
 import numpy as np
 import math
 

--- a/aggregation/rg_runs.py
+++ b/aggregation/rg_runs.py
@@ -18,10 +18,13 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-import aggregate, crystal, rotator, generator
+from . import aggregate, crystal, rotator, generator
 from numpy import array, random
 import numpy
-import cPickle as pickle
+try:
+  import cPickle as pickle
+except:
+  import pickle
 from scipy import stats
 
 

--- a/aggregation/riming.py
+++ b/aggregation/riming.py
@@ -19,13 +19,16 @@ SOFTWARE.
 """
 
 import argparse
-import cPickle as pickle
+try:
+  import cPickle as pickle
+except:
+  import pickle
 import gzip
 import os
 from numpy import random
 import numpy as np
 from scipy import stats
-import aggregate, crystal, rotator, generator, mcs
+from . import aggregate, crystal, rotator, generator, mcs
 
 
 rho_w = 1000.0

--- a/aggregation/riming_runs.py
+++ b/aggregation/riming_runs.py
@@ -18,7 +18,7 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 """
 
-from riming import *
+from .riming import *
 
 """This is here for backward compatibility and to provide a command
 line interface to rimed aggregate generation.

--- a/aggregation/rosette_runs.py
+++ b/aggregation/rosette_runs.py
@@ -20,7 +20,7 @@ SOFTWARE.
 
 import gzip
 import numpy as np
-import aggregate, generator, rotator, crystal
+from . import aggregate, generator, rotator, crystal
 
 def generate_rosette(D, min_grid_res=40e-6):
 	grid_res = min(D/20, min_grid_res)

--- a/aggregation/tripfreq_runs.py
+++ b/aggregation/tripfreq_runs.py
@@ -19,12 +19,15 @@ SOFTWARE.
 """
 
 import argparse
-import cPickle as pickle
+try:
+  import cPickle as pickle
+except:
+  import pickle
 import json
 from numpy import array, random
 import numpy as np
 from scipy import stats
-import aggregate, crystal, rotator, generator
+from . import aggregate, crystal, rotator, generator
 
 
 def generate_aggregate(monomer_generator,N=5,align=True):


### PR DESCRIPTION
There were a few issues caused by the package trying to import some of its scripts (I installed via `python setup.py install`). In addition, there are a few modules in Python 3 folded into the base install. This PR I believe fixes all of those, but may go about it in a way not preferred (e.g. the try, except pass).